### PR TITLE
fix: change log level to debug when exiting

### DIFF
--- a/main.go
+++ b/main.go
@@ -140,7 +140,7 @@ func processEvents(ctx context.Context, log *logrus.Entry, orch *relay.Orchestra
 		if err != nil {
 			log.Error("Error while stopping server", err)
 		}
-		log.Error("Exiting")
+		log.Debug("Exiting")
 	}
 
 	for {


### PR DESCRIPTION
I guess that the dev did not intend to put error level in the "Exiting" log event.

This log event prevents the target app to have a clean "error" trail of logs which is required when having a 0 errors policy.

Please consider accepting the pull request.
