### PR TITLE
fix: deprecate release-please manual workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,13 +4,15 @@ name: Release
 on:
   release:
     types: [published]
-  # for manual invokations
-  workflow_dispatch:
-    # not really used
-    inputs:
-      # the release tag automatically created
-      tag_name:
-        type: string
+
+# FIXME(kolesnikovae):
+#  # for manual invocations
+#  workflow_dispatch:
+#    # not really used
+#    inputs:
+#      # the release tag automatically created
+#      tag_name:
+#        type: string
 
 jobs:
   publish:

--- a/README.md
+++ b/README.md
@@ -109,7 +109,12 @@ aws lambda publish-layer-version \
   --zip-file "fileb://extension.zip"
 ```
 
-# Publishing
-```
-deno run --allow-env --allow-read --allow-run scripts/publish.ts --name=pyroscope-extension --dry-run=false
-```
+# Releasing
+
+Releases are managed by [`release-please`](https://github.com/googleapis/release-please). It assumes you are using [Conventional Commit messages].
+
+The most important prefixes you should have in mind are:
+
+ * `fix:` which represents bug fixes, and correlates to a SemVer patch.
+ * `feat:` which represents a new feature, and correlates to a SemVer minor.
+ * `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a SemVer major.


### PR DESCRIPTION
It's currently not possible to create a release manually. The workflow dispatch will always fail unless the release is created manually (which should be handled by release-please).

I also added a note about the use of release-please to the README. This workflow, along with its tooling (asdf, staticcheck, duno, etc.), is quite specific compared to our other repositories. I'd consider migrating to our standard toolchain and processes.